### PR TITLE
恢复取消按钮和置无效的按钮

### DIFF
--- a/openerp/addons/product/product_view.xml
+++ b/openerp/addons/product/product_view.xml
@@ -77,7 +77,7 @@
                                         <field name="list_price" invisible="1"/>
                                     </group>
                                     <group>
-                                        <field name="active" invisible="1"/>
+                                        <field name="active" groups="base.group_system"/>
                                     </group>
                                 </group>
                                 <group colspan="4">

--- a/openerp/addons/purchase/purchase_view.xml
+++ b/openerp/addons/purchase/purchase_view.xml
@@ -207,9 +207,7 @@
                     <button name="view_invoice" string="Receive Invoice" type="object" attrs="{'invisible': ['|', ('invoice_method','in', ['picking', 'manual']), '|', ('state','not in', ['approved','invoiced','pickinged']), ('invoiced','=',True) ]}" class="oe_highlight"/>
                     -->
                     <button name="action_cancel_draft" states="cancel,sent,confirmed" string="Set to Draft" type="object" />
-                    <!--
-                    <button name="action_cancel" states="draft,confirmed,sent,bid,approved,except_picking,except_invoice" string="Cancel" type="object" />
-                -->
+                    <button name="action_cancel" states="draft,confirmed,sent,bid,approved,invoiced,except_picking,except_invoice" string="Cancel" type="object" />
                     <field name="state" widget="statusbar" statusbar_visible="draft,approved,done" statusbar_colors='{"except_picking":"red","except_invoice":"red","confirmed":"blue"}' readonly="1"/>
                 </header>
                 <sheet>


### PR DESCRIPTION
1. 恢复了采购单的取消按钮，仓库人员可以自行取消错误的采购单；
2. 恢复了SKU编辑页面的置无效的按钮，便于隐藏要下线的sku