### PR TITLE
Odoo权限扩展，修改Domain表达式可以调用数据库游标cr

### DIFF
--- a/openerp/addons/base/ir/ir_rule.py
+++ b/openerp/addons/base/ir/ir_rule.py
@@ -50,7 +50,7 @@ class ir_rule(osv.osv):
         eval_context = self._eval_context(cr, uid)
         for rule in self.browse(cr, uid, ids, context):
             if rule.domain_force:
-                res[rule.id] = expression.normalize_domain(eval(rule.domain_force, eval_context))
+                res[rule.id] = expression.normalize_domain(eval(rule.domain_force, eval_context,locals_dict={'cr':cr}))
             else:
                 res[rule.id] = []
         return res


### PR DESCRIPTION
满足一些权限组隔离策略，可以获取到原有domain中获取不到的数据