### PR TITLE
修改仓库面板

### DIFF
--- a/openerp/addons/stock/static/src/css/stock.css
+++ b/openerp/addons/stock/static/src/css/stock.css
@@ -23,7 +23,9 @@
     -o-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
     -box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
-
+.openerp .oe_kanban_view .oe_kanban_action_a{
+    font-size: 14px;
+}
 .oe_product_photo {
     width: 80px;
     height: auto;

--- a/openerp/addons/stock/static/src/css/stock.css
+++ b/openerp/addons/stock/static/src/css/stock.css
@@ -77,10 +77,10 @@
 }
 .openerp .oe_kanban_view .oe_kanban_stock_picking_type .oe_items_list {
     position: relative;
-    margin: 10px;
+    margin: 20px 10px;
 }
 .openerp .oe_kanban_view .oe_kanban_stock_picking_type .oe_items_list div {
-    width: 160px;
+    width: 155px;
     height: 22px;
     margin: 0 !important;
     position: relative;

--- a/openerp/addons/stock/stock.py
+++ b/openerp/addons/stock/stock.py
@@ -4357,7 +4357,7 @@ class stock_picking_type(osv.osv):
         domains = {
             'count_picking_draft': [('state', '=', 'draft')],
             'count_picking_waiting': [('state', '=', 'confirmed')],
-            'count_picking_ready': [('state', 'in', ('assigned', 'partially_available'))],
+            'count_picking_ready': [('state', 'in', ('draft','confirmed','assigned', 'partially_available'))],
             'count_picking': [('state', 'in', ('assigned', 'waiting', 'confirmed', 'partially_available'))],
             'count_picking_late': [('min_date', '<', time.strftime(DEFAULT_SERVER_DATETIME_FORMAT)), ('state', 'in', ('assigned', 'waiting', 'confirmed', 'partially_available'))],
             'count_picking_backorders': [('backorder_id', '!=', False), ('state', 'in', ('confirmed', 'assigned', 'waiting', 'partially_available'))],

--- a/openerp/addons/stock/stock_view.xml
+++ b/openerp/addons/stock/stock_view.xml
@@ -1378,9 +1378,11 @@
                                             <a name="162" type="action">
                                                 <field name="count_picking_ready"/> Ready
                                             </a>
+                                            <!--
                                             <a name="161" type="action" class="oe_sparkline_bar_link">
                                                 <field invisible="1" name="last_done_picking" widget="sparkline_bar" options="{'type': 'tristate', 'colorMap': {'0': 'orange', '-1': 'red', '1': 'green'}}">Last 10 Done Operations</field>
                                             </a>
+                                        -->
                                         </div>
                                         <div t-if="record.count_picking_waiting.raw_value &gt; 0">
                                             <a name="164" type="action">

--- a/openerp/addons/stock/stock_view.xml
+++ b/openerp/addons/stock/stock_view.xml
@@ -1384,11 +1384,13 @@
                                             </a>
                                         -->
                                         </div>
+                                        <!--
                                         <div t-if="record.count_picking_waiting.raw_value &gt; 0">
                                             <a name="164" type="action">
                                                 <field name="count_picking_waiting"/> Waiting Availability
                                             </a>
                                         </div>
+                                    -->
                                         <div>
                                             <a name="167" type="action">All Operations</a>
                                         </div>

--- a/openerp/addons/stock/stock_view.xml
+++ b/openerp/addons/stock/stock_view.xml
@@ -1376,8 +1376,8 @@
                                     <div class="oe_items_list oe_kanban_ellipsis">
                                         <div>
                                             <a name="162" type="action">
-                                                <field name="count_picking_ready"/> Ready
-                                            </a>
+                                                Ready 
+                                             <span style="color:red;"><field name="count_picking_ready"/></span></a>
                                             <!--
                                             <a name="161" type="action" class="oe_sparkline_bar_link">
                                                 <field invisible="1" name="last_done_picking" widget="sparkline_bar" options="{'type': 'tristate', 'colorMap': {'0': 'orange', '-1': 'red', '1': 'green'}}">Last 10 Done Operations</field>


### PR DESCRIPTION
1、修改仓库面板“待录入”按钮能够看到“草稿”和“待审核”类型的单据。
2、修改仓库面板的UI，合并“全部操作”及“待录入”显示在同一行。